### PR TITLE
docs: add house-style status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # ood-sagemaker-training-adapter
 
+[![CI](https://github.com/scttfrdmn/ood-sagemaker-training-adapter/actions/workflows/ci.yml/badge.svg)](https://github.com/scttfrdmn/ood-sagemaker-training-adapter/actions/workflows/ci.yml)
+[![Go Report Card](https://goreportcard.com/badge/github.com/scttfrdmn/ood-sagemaker-training-adapter)](https://goreportcard.com/report/github.com/scttfrdmn/ood-sagemaker-training-adapter)
+[![codecov](https://codecov.io/gh/scttfrdmn/ood-sagemaker-training-adapter/branch/main/graph/badge.svg)](https://codecov.io/gh/scttfrdmn/ood-sagemaker-training-adapter)
+[![Go Reference](https://pkg.go.dev/badge/github.com/scttfrdmn/ood-sagemaker-training-adapter.svg)](https://pkg.go.dev/github.com/scttfrdmn/ood-sagemaker-training-adapter)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
 An [Open OnDemand](https://openondemand.org/) compute adapter that translates OOD job submissions into [AWS SageMaker Training Jobs](https://docs.aws.amazon.com/sagemaker/latest/dg/how-it-works-training.html).
 
 > **Distinct from `ood-sagemaker-adapter`** — that adapter targets SageMaker Studio apps (interactive sessions). This adapter targets batch training workloads via the SageMaker Training Jobs API.


### PR DESCRIPTION
Adds the ecosystem house-style status badges to the README header: **CI**, **Go Report Card**, **codecov**, **Go Reference** (pkg.go.dev), and **License: MIT**.

Matches the badge level used across the spore-host projects, adapted to this Go adapter. MIT badge reflects the OOD ecosystem license (Open OnDemand itself is MIT). Docs-only.